### PR TITLE
Add portfolio data and display on homepage

### DIFF
--- a/src/data/portfolio.json
+++ b/src/data/portfolio.json
@@ -1,0 +1,24 @@
+{
+  "profile": {
+    "name": "John Doe",
+    "title": "Full Stack Developer",
+    "bio": "Building modern web applications with Astro and Vue."
+  },
+  "projects": [
+    {
+      "name": "Portfolio Website",
+      "description": "Personal portfolio built with Astro.",
+      "url": "https://example.com/portfolio"
+    },
+    {
+      "name": "Todo App",
+      "description": "A simple todo application using Vue.",
+      "url": "https://example.com/todo"
+    }
+  ],
+  "socials": {
+    "github": "https://github.com/johndoe",
+    "twitter": "https://twitter.com/johndoe",
+    "linkedin": "https://linkedin.com/in/johndoe"
+  }
+}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,16 +1,34 @@
 ---
 import '../styles/global.css';
+import portfolio from '../data/portfolio.json';
+const { profile, projects, socials } = portfolio;
 ---
 
 <html lang="en">
-	<head>
-		<meta charset="utf-8" />
-		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-		<meta name="viewport" content="width=device-width" />
-		<meta name="generator" content={Astro.generator} />
-		<title>Astro</title>
-	</head>
-	<body>
-                <h1 class="text-2xl font-bold">Astro</h1>
-        </body>
+  <head>
+    <meta charset="utf-8" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <meta name="viewport" content="width=device-width" />
+    <meta name="generator" content={Astro.generator} />
+    <title>{profile.name}'s Portfolio</title>
+  </head>
+  <body>
+    <h1 class="text-2xl font-bold">{profile.name}</h1>
+    <p>{profile.title}</p>
+    <p>{profile.bio}</p>
+
+    <h2 class="mt-4 text-xl font-semibold">Projects</h2>
+    <ul>
+      {projects.map(project => (
+        <li><a href={project.url}>{project.name}</a> - {project.description}</li>
+      ))}
+    </ul>
+
+    <h2 class="mt-4 text-xl font-semibold">Socials</h2>
+    <ul>
+      {Object.entries(socials).map(([network, url]) => (
+        <li><a href={url}>{network}</a></li>
+      ))}
+    </ul>
+  </body>
 </html>


### PR DESCRIPTION
## Summary
- add portfolio JSON data with profile, projects, and social links
- import data in homepage and render profile, project list, and social links

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68abfe1be2cc83268970fb139c4f0898