### PR TITLE
feat: expand portfolio with multi-page layout

### DIFF
--- a/src/components/Footer.vue
+++ b/src/components/Footer.vue
@@ -1,0 +1,18 @@
+<script setup>
+import portfolio from '../data/portfolio.json';
+const { socials, profile } = portfolio;
+</script>
+
+<template>
+  <footer class="bg-gray-100 mt-12">
+    <section class="max-w-5xl mx-auto p-6 text-center">
+      <h2 class="text-lg font-semibold mb-2">Find me on</h2>
+      <ul class="flex justify-center space-x-4">
+        <li v-for="(url, network) in socials" :key="network">
+          <a :href="url" class="text-blue-600 hover:underline" target="_blank" rel="noopener noreferrer">{{ network }}</a>
+        </li>
+      </ul>
+      <p class="mt-6 text-sm text-gray-500">&copy; {{ new Date().getFullYear() }} {{ profile.name }}</p>
+    </section>
+  </footer>
+</template>

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -1,0 +1,16 @@
+<script setup>
+</script>
+
+<template>
+  <header class="bg-white shadow-md">
+    <nav class="max-w-5xl mx-auto px-6 py-4 flex items-center justify-between">
+      <a href="/" class="text-xl font-semibold text-blue-600">MyPortfolio</a>
+      <ul class="flex space-x-4 text-gray-700">
+        <li><a class="hover:text-blue-600 transition" href="/about">About</a></li>
+        <li><a class="hover:text-blue-600 transition" href="/projects">Projects</a></li>
+        <li><a class="hover:text-blue-600 transition" href="/blog">Blog</a></li>
+        <li><a class="hover:text-blue-600 transition" href="/contact">Contact</a></li>
+      </ul>
+    </nav>
+  </header>
+</template>

--- a/src/components/Hero.vue
+++ b/src/components/Hero.vue
@@ -1,0 +1,13 @@
+<script setup>
+import portfolio from '../data/portfolio.json';
+const { profile } = portfolio;
+</script>
+
+<template>
+  <section class="text-center py-20 bg-gradient-to-b from-blue-50 to-white animate-fade-in">
+    <img :src="profile.photo" :alt="profile.name" class="w-32 h-32 mx-auto rounded-full mb-6 shadow-lg" />
+    <h1 class="text-4xl font-bold mb-2">{{ profile.name }}</h1>
+    <p class="text-xl text-gray-600">{{ profile.title }}</p>
+    <p class="mt-4 max-w-xl mx-auto text-gray-700">{{ profile.bio }}</p>
+  </section>
+</template>

--- a/src/components/Profile.vue
+++ b/src/components/Profile.vue
@@ -4,10 +4,11 @@ const { profile } = portfolio;
 </script>
 
 <template>
-  <section class="max-w-xl mx-auto text-center p-6">
+  <section class="max-w-2xl mx-auto text-center p-6 space-y-4 animate-fade-in">
+    <img :src="profile.photo" :alt="profile.name" class="w-48 h-48 rounded-full mx-auto shadow-lg" />
     <h1 class="text-3xl font-bold tracking-tight">{{ profile.name }}</h1>
     <p class="text-xl text-gray-600">{{ profile.title }}</p>
-    <p class="mt-4 text-gray-700">{{ profile.bio }}</p>
+    <p class="mt-4 text-gray-700">{{ profile.about }}</p>
   </section>
 </template>
 

--- a/src/components/Projects.vue
+++ b/src/components/Projects.vue
@@ -1,14 +1,30 @@
 <script setup>
 import portfolio from '../data/portfolio.json';
-const { projects } = portfolio;
+const props = defineProps({
+  projects: {
+    type: Array,
+    default: null,
+  },
+});
+const allProjects = props.projects || portfolio.projects;
 </script>
 
 <template>
-  <section class="max-w-xl mx-auto p-6">
+  <section class="max-w-5xl mx-auto p-6">
     <h2 class="text-2xl font-semibold mb-4">Projects</h2>
-    <ul class="space-y-4">
-      <li v-for="project in projects" :key="project.name" class="border rounded-md p-4 hover:bg-gray-50">
-        <a :href="project.url" class="text-blue-600 hover:underline font-medium" target="_blank" rel="noopener noreferrer">{{ project.name }}</a>
+    <ul class="grid md:grid-cols-2 gap-4">
+      <li
+        v-for="project in allProjects"
+        :key="project.name"
+        class="border rounded-md p-4 hover:shadow-lg transition transform hover:-translate-y-1"
+      >
+        <a
+          :href="project.url"
+          class="text-blue-600 hover:underline font-medium"
+          target="_blank"
+          rel="noopener noreferrer"
+          >{{ project.name }}</a
+        >
         <p class="text-sm text-gray-600 mt-1">{{ project.description }}</p>
       </li>
     </ul>

--- a/src/data/portfolio.json
+++ b/src/data/portfolio.json
@@ -2,7 +2,9 @@
   "profile": {
     "name": "John Doe",
     "title": "Full Stack Developer",
-    "bio": "Building modern web applications with Astro and Vue."
+    "bio": "Building modern web applications with Astro and Vue.",
+    "about": "I am a passionate developer who loves crafting scalable and maintainable web applications. With experience across the stack, I enjoy turning ideas into reality.",
+    "photo": "https://placehold.co/400x400.png"
   },
   "projects": [
     {
@@ -16,9 +18,23 @@
       "url": "https://example.com/todo"
     }
   ],
+  "posts": [
+    {
+      "slug": "getting-started",
+      "title": "Getting Started",
+      "date": "2024-01-01",
+      "excerpt": "An introduction to my journey as a developer.",
+      "content": "This is the first post in my new blog. Stay tuned for more updates on my projects and learning experiences."
+    }
+  ],
   "socials": {
     "github": "https://github.com/johndoe",
     "twitter": "https://twitter.com/johndoe",
     "linkedin": "https://linkedin.com/in/johndoe"
+  },
+  "contact": {
+    "email": "john@example.com",
+    "phone": "+1 234 567 890",
+    "location": "Anytown, Earth"
   }
 }

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -1,0 +1,23 @@
+---
+import '../styles/global.css';
+import Header from '../components/Header.vue';
+import Footer from '../components/Footer.vue';
+import Profile from '../components/Profile.vue';
+import portfolio from '../data/portfolio.json';
+const { profile } = portfolio;
+---
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width" />
+    <title>About - {profile.name}</title>
+    <meta name="description" content={profile.bio} />
+  </head>
+  <body>
+    <Header />
+    <main>
+      <Profile />
+    </main>
+    <Footer />
+  </body>
+</html>

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -1,0 +1,31 @@
+---
+import '../../styles/global.css';
+import Header from '../../components/Header.vue';
+import Footer from '../../components/Footer.vue';
+import portfolio from '../../data/portfolio.json';
+
+export function getStaticPaths() {
+  const { posts } = portfolio;
+  return posts.map((p) => ({ params: { slug: p.slug }, props: { post: p } }));
+}
+
+const { post } = Astro.props;
+const { profile } = portfolio;
+---
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width" />
+    <title>{post.title} - {profile.name}</title>
+    <meta name="description" content={post.excerpt} />
+  </head>
+  <body>
+    <Header />
+    <main class="max-w-3xl mx-auto p-6 space-y-4">
+      <h1 class="text-3xl font-bold">{post.title}</h1>
+      <p class="text-sm text-gray-500">{post.date}</p>
+      <p class="text-gray-700">{post.content}</p>
+    </main>
+    <Footer />
+  </body>
+</html>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -1,0 +1,31 @@
+---
+import '../../styles/global.css';
+import Header from '../../components/Header.vue';
+import Footer from '../../components/Footer.vue';
+import portfolio from '../../data/portfolio.json';
+const { posts, profile } = portfolio;
+---
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width" />
+    <title>Blog - {profile.name}</title>
+    <meta name="description" content={`Blog posts by ${profile.name}`} />
+  </head>
+  <body>
+    <Header />
+    <main class="max-w-3xl mx-auto p-6">
+      <h1 class="text-3xl font-bold mb-6">Blog</h1>
+      <ul class="space-y-6">
+        {posts.map((post) => (
+          <li>
+            <a class="text-2xl text-blue-600 hover:underline" href={`/blog/${post.slug}`}>{post.title}</a>
+            <p class="text-sm text-gray-500">{post.date}</p>
+            <p class="text-gray-700 mt-2">{post.excerpt}</p>
+          </li>
+        ))}
+      </ul>
+    </main>
+    <Footer />
+  </body>
+</html>

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -1,0 +1,31 @@
+---
+import '../styles/global.css';
+import Header from '../components/Header.vue';
+import Footer from '../components/Footer.vue';
+import portfolio from '../data/portfolio.json';
+const { contact, profile } = portfolio;
+---
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width" />
+    <title>Contact - {profile.name}</title>
+    <meta name="description" content="Get in touch with {profile.name}" />
+  </head>
+  <body>
+    <Header />
+    <main class="max-w-xl mx-auto p-6 space-y-4">
+      <h1 class="text-3xl font-bold mb-4">Contact</h1>
+      <p>Email: <a class="text-blue-600 hover:underline" href={`mailto:${contact.email}`}>{contact.email}</a></p>
+      <p>Phone: {contact.phone}</p>
+      <p>Location: {contact.location}</p>
+      <form class="space-y-4 mt-6">
+        <input type="text" placeholder="Name" class="w-full border rounded px-3 py-2" />
+        <input type="email" placeholder="Email" class="w-full border rounded px-3 py-2" />
+        <textarea placeholder="Message" class="w-full border rounded px-3 py-2"></textarea>
+        <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700 transition">Send</button>
+      </form>
+    </main>
+    <Footer />
+  </body>
+</html>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,9 +1,13 @@
 ---
 import '../styles/global.css';
-import Profile from '../components/Profile.vue';
+import Header from '../components/Header.vue';
+import Hero from '../components/Hero.vue';
 import Projects from '../components/Projects.vue';
+import Footer from '../components/Footer.vue';
 import portfolio from '../data/portfolio.json';
-const { profile, socials } = portfolio;
+const { profile, projects, posts } = portfolio;
+const featuredProjects = projects.slice(0, 2);
+const recentPosts = posts.slice(0, 2);
 ---
 
 <html lang="en">
@@ -20,23 +24,37 @@ const { profile, socials } = portfolio;
     />
   </head>
   <body>
-    <header>
-      <Profile />
-    </header>
+    <Header />
     <main>
-      <Projects />
-    </main>
-    <footer>
-      <section class="max-w-xl mx-auto p-6">
-        <h2 class="text-xl font-semibold mb-2">Socials</h2>
-        <ul class="space-y-1">
-          {Object.entries(socials).map(([network, url]) => (
-            <li>
-              <a class="text-blue-600 hover:underline" href={url}>{network}</a>
+      <Hero />
+      <section class="max-w-5xl mx-auto p-6">
+        <h2 class="text-2xl font-semibold mb-4">Projects</h2>
+        <Projects projects={featuredProjects} />
+        <div class="text-right mt-2">
+          <a href="/projects" class="text-blue-600 hover:underline">View all projects →</a>
+        </div>
+      </section>
+      <section class="max-w-5xl mx-auto p-6">
+        <h2 class="text-2xl font-semibold mb-4">Blog</h2>
+        <ul class="space-y-4">
+          {recentPosts.map((post) => (
+            <li class="border-b pb-4">
+              <a href={`/blog/${post.slug}`} class="text-xl text-blue-600 hover:underline">{post.title}</a>
+              <p class="text-sm text-gray-500">{post.date}</p>
+              <p class="text-gray-700">{post.excerpt}</p>
             </li>
           ))}
         </ul>
+        <div class="text-right mt-2">
+          <a href="/blog" class="text-blue-600 hover:underline">Read more posts →</a>
+        </div>
       </section>
-    </footer>
+      <section class="max-w-5xl mx-auto p-6 text-center">
+        <h2 class="text-2xl font-semibold mb-4">Get in Touch</h2>
+        <p class="mb-4">Interested in working together or have a question?</p>
+        <a href="/contact" class="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700 transition">Contact Me</a>
+      </section>
+    </main>
+    <Footer />
   </body>
 </html>

--- a/src/pages/projects.astro
+++ b/src/pages/projects.astro
@@ -1,0 +1,23 @@
+---
+import '../styles/global.css';
+import Header from '../components/Header.vue';
+import Footer from '../components/Footer.vue';
+import Projects from '../components/Projects.vue';
+import portfolio from '../data/portfolio.json';
+const { profile } = portfolio;
+---
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width" />
+    <title>Projects - {profile.name}</title>
+    <meta name="description" content="Projects by {profile.name}" />
+  </head>
+  <body>
+    <Header />
+    <main>
+      <Projects />
+    </main>
+    <Footer />
+  </body>
+</html>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,3 +1,23 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+html {
+  scroll-behavior: smooth;
+}
+
+@layer utilities {
+  @keyframes fade-in {
+    from {
+      opacity: 0;
+      transform: translateY(1rem);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+  .animate-fade-in {
+    animation: fade-in 0.8s ease-out forwards;
+  }
+}


### PR DESCRIPTION
## Summary
- add global header, hero section, and footer
- build out about, projects, blog, and contact pages
- extend portfolio data with posts and contact info
- replace local profile image with remote placeholder

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ac326323bc832699f701efe108353f